### PR TITLE
remove rider from create deliveries migration

### DIFF
--- a/db/migrate/20221011213804_create_deliveries.rb
+++ b/db/migrate/20221011213804_create_deliveries.rb
@@ -6,11 +6,5 @@ class CreateDeliveries < ActiveRecord::Migration[7.0]
 
       t.timestamps
     end
-
-    rider = Rider.create!(name: 'Test Rider Name',
-                          email: 'test@test.com',
-                          mobile: 123_456_789)
-
-    Delivery.update_all(rider_id: rider.id)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_24_202513) do
+ActiveRecord::Schema.define(version: 2022_10_22_210318) do
 
   create_table "carts", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
The create_deliveries migration file containes an object from Rider model that because of later changes on the that model stops execution of rails db:migrate when we drop and recreate the table. That code needs to be removed.