### PR TITLE
add missing translation for placeholder

### DIFF
--- a/config/locales/administrate.mk.yml
+++ b/config/locales/administrate.mk.yml
@@ -1,0 +1,5 @@
+mk:
+  administrate:
+    search:
+      label: "Барај..."
+      


### PR DESCRIPTION
We have a missing translation on admin dashboard so an administrate yml file was created to fix this.
The placeholder in the Serach form displayed HTML tags like this:
![image](https://user-images.githubusercontent.com/60677366/210392172-f9f83c4f-1f94-4cab-ab3f-ea59b62b9176.png)
